### PR TITLE
Add SPC demos with of WebAuthn extensions.

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
           <li><a href="pr/spc-clear-browser-cache/">Clearing browser cache </a></li>
           <li><a href="pr/spc-false-positive/">False positive matching</a></li>
         </ul></li>
+        <li>WebAuthn Extensions demos (experimental)<ul>
+            <li><a href="pr/spc-devicepubkey/">DevicePubKey extension demo</a></li>
+            <li><a href="pr/spc-large-blob/">LargeBlob extension demo</a></li>
+        </ul></li>
         <li><a href="pr/spc-activationless/">Activationless demo</a></li>
     </ul></li>
 

--- a/pr/spc-devicepubkey/index.html
+++ b/pr/spc-devicepubkey/index.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Secure Payment Confirmation (WebAuthn Extension Device Public Key)
+  </title>
+  <link rel="icon" href="/favicon.ico">
+  <link rel="stylesheet" type="text/css" href="../style.css">
+</head>
+
+<body>
+  <div id="contents">
+    <h1>Secure Payment Confirmation (WebAuthn Extension Device Public Key)</h1>
+    <p>This is a test website. Nothing is charged.</p>
+    </pre>
+    <p><button
+          onclick="createPaymentCredential(
+            'Credential #1', /* devicePubKey= */ true)">
+      Enroll Credential #1 with DevicePublicKey</button>
+    </p>
+    <p>
+      <button
+        onclick="onBuyClicked('Credential #1', /* getDevicePubKey= */true)">
+        Pay $0.01 and get devicePubKey</button></p>
+    <p>
+      <button
+        onclick="webAuthnGet('Credential #1', /* getDevicePubKey= */true)">
+      Login and get devicePubKey</button></p>
+  </div>
+  <pre id="msg"></pre>
+  <script src="../util.js"></script>
+  <script src="../spc_util.js"></script>
+  <script src="pr.js"></script>
+  <script src="/redirect.js"></script>
+</body>
+
+</html>

--- a/pr/spc-devicepubkey/pr.js
+++ b/pr/spc-devicepubkey/pr.js
@@ -1,0 +1,103 @@
+/* exported createPaymentCredential */
+/* exported onBuyClicked */
+
+const windowLocalStorageIdentifier = 'spc-devicepubkey';
+
+/**
+ * Creates a payment credential.
+ */
+async function createPaymentCredential(devicePubKey = false) {
+  try {
+    const publicKeyCredential = await createCredential(
+        /*setPaymentExtension=*/ true, /*optionalOverrides=*/ {
+          additionalExtensions: buildExtensions(devicePubKey),
+        });
+    console.log(publicKeyCredential);
+    window.localStorage.setItem(windowLocalStorageIdentifier,
+      arrayBufferToBase64(publicKeyCredential.rawId));
+    info(
+        'Enrolled: ' + objectToString(publicKeyCredential) + '\n' +
+        'Extensions: ' + extensionsOutputToString(publicKeyCredential));
+  } catch (err) {
+    error(err);
+  }
+}
+
+/**
+ * Launches payment request for SPC.
+ */
+async function onBuyClicked(getDevicePubKey = false) {
+  try {
+    const request = await createSPCPaymentRequest(
+        {
+          credentialIds: [base64ToArray(
+              window.localStorage.getItem(windowLocalStorageIdentifier))],
+          extensions: buildExtensions(getDevicePubKey),
+        });
+
+    try {
+      const canMakePayment = await request.canMakePayment();
+      info(`canMakePayment result: ${canMakePayment}`);
+    } catch (err) {
+      error(`Error from canMakePayment: ${error.message}`);
+    }
+
+    const instrumentResponse = await request.show();
+    await instrumentResponse.complete('success')
+    console.log(instrumentResponse);
+    info(
+        'Payment response: ' + objectToString(instrumentResponse) + '\n' +
+        'Extensions: ' + extensionsOutputToString(instrumentResponse.details));
+  } catch (err) {
+    error(err);
+  }
+}
+
+async function webAuthnGet(getDevicePubKey) {
+  try {
+    const publicKey = {
+      challenge: new TextEncoder().encode('Authentication challenge'),
+      userVerification: 'required',
+      allowCredentials: [{
+        transports: ['internal'],
+        type: 'public-key',
+        id: base64ToArray(window.localStorage.getItem(
+          windowLocalStorageIdentifier)),
+      }, ],
+      extensions: buildExtensions(getDevicePubKey),
+    };
+    const credentialInfoAssertion = await navigator.credentials.get({
+      publicKey
+    });
+    console.log(credentialInfoAssertion);
+    info(
+        'Successful login: ' + objectToString(credentialInfoAssertion) + '\n' +
+        'Extensions: ' + extensionsOutputToString(credentialInfoAssertion));
+  } catch (err) {
+    error(err);
+  }
+}
+
+function buildExtensions(getDevicePubKey) {
+  if (getDevicePubKey) {
+    return {
+      devicePubKey: {},
+    };
+  } else {
+    return {};
+  }
+}
+
+function extensionsOutputToString(credentialInfoAssertion) {
+  const clientExtensionResults =
+      credentialInfoAssertion.getClientExtensionResults();
+  const devicePubKey = clientExtensionResults.devicePubKey;
+  if (devicePubKey !== undefined) {
+    devicePubKey.authenticatorOutput =
+        arrayBufferToBase64(devicePubKey.authenticatorOutput);
+    devicePubKey.signature = arrayBufferToBase64(devicePubKey.signature);
+  }
+  return JSON.stringify(
+      clientExtensionResults, /*replacer=*/ undefined,
+      /*space=*/ 2);
+}

--- a/pr/spc-large-blob/index.html
+++ b/pr/spc-large-blob/index.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Secure Payment Confirmation (WebAuthn Extension Large Blob)</title>
+  <link rel="icon" href="/favicon.ico">
+  <link rel="stylesheet" type="text/css" href="../style.css">
+</head>
+
+<body>
+  <div id="contents">
+    <h1>Secure Payment Confirmation (WebAuthn Extension Large Blob)</h1>
+    <p>This is a test website. Nothing is charged.</p>
+    </pre>
+    <p><button
+          onclick="createPaymentCredential(
+            'Credential #1', /* requireLargeBlobSupport= */ true)">
+      Enroll with Large Blob Support</button>
+    <p>
+      <button
+        onclick="onBuyClicked('Credential #1', LargeBlobMode.Write)">
+        Pay $0.01 and write largeBlob "SecurePaymentConfirmation"</button>
+      </p>
+    <p>
+      <button
+        onclick="onBuyClicked('Credential #1', LargeBlobMode.Read)">
+        Pay $0.01 and read largeBlob</button>
+      </p>
+    <p><button onclick="webAuthnGet('Credential #1', LargeBlobMode.Write)">
+      Login and write largeBlob "WebAuthn"</button></p>
+    <p><button onclick="webAuthnGet('Credential #1', LargeBlobMode.Read)">
+      Login and read largeBlob</button></p>
+  </div>
+  <pre id="msg"></pre>
+  <script src="../util.js"></script>
+  <script src="../spc_util.js"></script>
+  <script src="pr.js"></script>
+  <script src="/redirect.js"></script>
+</body>
+
+</html>

--- a/pr/spc-large-blob/pr.js
+++ b/pr/spc-large-blob/pr.js
@@ -1,0 +1,133 @@
+/* exported createPaymentCredential */
+/* exported onBuyClicked */
+
+/**
+ * Creates a payment credential.
+ */
+async function createPaymentCredential(
+    windowLocalStorageIdentifier,
+    requireLargeBlobSupport = false,
+) {
+  try {
+    const publicKeyCredential = await createCredential(
+        /*setPaymentExtension=*/ true, /*optionalOverrides=*/ {
+          additionalExtensions: buildEnrollExtensions(requireLargeBlobSupport),
+        });
+    console.log(publicKeyCredential);
+    window.localStorage.setItem(
+        windowLocalStorageIdentifier,
+        arrayBufferToBase64(publicKeyCredential.rawId));
+    info(
+        'Enrolled: ' + objectToString(publicKeyCredential) + '\n' +
+        'Extensions: ' + extensionsOutputToString(publicKeyCredential));
+  } catch (err) {
+    error(err);
+  }
+}
+
+/**
+ * Launches payment request for SPC.
+ */
+async function onBuyClicked(
+    windowLocalStorageIdentifier, largeBlobMode = LargeBlobMode.None) {
+  try {
+    const request = await createSPCPaymentRequest({
+      credentialIds: [base64ToArray(
+          window.localStorage.getItem(windowLocalStorageIdentifier))],
+      extensions: buildLoginExtensions(
+          largeBlobMode, /* textToWrite= */ 'SecurePaymentConfirmation'),
+    });
+
+    try {
+      const canMakePayment = await request.canMakePayment();
+      info(`canMakePayment result: ${canMakePayment}`);
+    } catch (err) {
+      error(`Error from canMakePayment: ${error.message}`);
+    }
+
+    const instrumentResponse = await request.show();
+    await instrumentResponse.complete('success')
+    console.log(instrumentResponse);
+    info(
+        'Payment response: ' + objectToString(instrumentResponse) + '\n' +
+        'Extensions: ' + extensionsOutputToString(instrumentResponse.details));
+  } catch (err) {
+    error(err);
+  }
+}
+
+async function webAuthnGet(windowLocalStorageIdentifier, largeBlobMode) {
+  try {
+    const publicKey = {
+      challenge: new TextEncoder().encode('Authentication challenge'),
+      userVerification: 'required',
+      allowCredentials: [
+        {
+          transports: ['internal'],
+          type: 'public-key',
+          id: base64ToArray(
+              window.localStorage.getItem(windowLocalStorageIdentifier)),
+        },
+      ],
+      extensions: buildLoginExtensions(largeBlobMode),
+    };
+    const credentialInfoAssertion =
+        await navigator.credentials.get({publicKey});
+    console.log(credentialInfoAssertion);
+    info(
+        'Login: ' + objectToString(credentialInfoAssertion) + '\n' +
+        'Extensions: ' + extensionsOutputToString(credentialInfoAssertion));
+  } catch (err) {
+    error(err);
+  }
+}
+
+const LargeBlobMode = {
+  None: 'None',
+  Read: 'Read',
+  Write: 'Write',
+};
+
+function buildEnrollExtensions(requireLargeBlobSupport) {
+  if (requireLargeBlobSupport) {
+    return {
+      largeBlob: {
+        support: 'required',
+      }
+    };
+  } else {
+    return {};
+  }
+}
+
+function buildLoginExtensions(mode, textToWrite = 'WebAuthn') {
+  if (mode === LargeBlobMode.None) {
+    return {};
+  } else if (mode === LargeBlobMode.Write) {
+    buffer = new TextEncoder().encode(textToWrite);
+    return {
+      largeBlob: {
+        write: buffer,
+      },
+    };
+  } else if (mode === LargeBlobMode.Read) {
+    return {
+      largeBlob: {
+        read: true,
+      }
+    };
+  }
+}
+
+function extensionsOutputToString(credentialInfoAssertion) {
+  const clientExtensionResults =
+      credentialInfoAssertion.getClientExtensionResults();
+  if (clientExtensionResults.largeBlob !== undefined &&
+      clientExtensionResults.largeBlob.blob !== undefined) {
+    clientExtensionResults.largeBlob.blob =
+        arrayBufferToString(clientExtensionResults.largeBlob.blob);
+  }
+  return JSON.stringify(
+      clientExtensionResults, /*replacer=*/ undefined,
+      /*space=*/ 2);
+}

--- a/pr/spc_util.js
+++ b/pr/spc_util.js
@@ -10,7 +10,8 @@
  * @return {PublicKeyCredential} the created credential.
  */
 async function createCredential(setPaymentExtension, optionalOverrides = {}) {
-  const {userIdOverride, residentKeyOverride} = optionalOverrides;
+  const {userIdOverride, residentKeyOverride, additionalExtensions} =
+      optionalOverrides;
   const rp = {
     id: window.location.hostname,
     name: 'Rouslan Solomakhin',
@@ -49,8 +50,16 @@ async function createCredential(setPaymentExtension, optionalOverrides = {}) {
     },
   };
 
-  if (setPaymentExtension)
-    publicKey['extensions'] = {payment: {isPayment: true}};
+  if (setPaymentExtension || additionalExtensions !== undefined) {
+    publicKey['extensions'] = additionalExtensions !== undefined
+        ? additionalExtensions
+        : {};
+    if (setPaymentExtension) {
+      publicKey['extensions']['payment'] = {
+        isPayment: true,
+      };
+    }
+  }
 
   return await navigator.credentials.create({publicKey});
 }


### PR DESCRIPTION
Add two secure payment confirmation examples using WebAuthn extensions. One page demos large blob storage and another demos device public key.